### PR TITLE
Fix deprecation warning for terraform v0.7

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 
-resource "template_file" "cloudformation_sns_stack" {
+data "template_file" "cloudformation_sns_stack" {
     template = "${file("${path.module}/templates/email-sns-stack.json.tpl")}"
 
     vars {
@@ -12,7 +12,7 @@ resource "template_file" "cloudformation_sns_stack" {
 
 resource "aws_cloudformation_stack" "sns-topic" {
     name = "${var.stack_name}"
-    template_body = "${template_file.cloudformation_sns_stack.rendered}"
+    template_body = "${data.template_file.cloudformation_sns_stack.rendered}"
 
     tags {
         Owner = "${var.owner}"


### PR DESCRIPTION
`template_file` resource now outputs deprecation warning for terraform v0.7. 

https://www.terraform.io/upgrade-guides/0-7.html#template_file
