### PR TITLE
fixed the error outputs.ARN on new tf version

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "arn" {
-    value = "${aws_cloudformation_stack.sns-topic.outputs.ARN}"
+    value = "${aws_cloudformation_stack.sns-topic.outputs["ARN"]}"
 }


### PR DESCRIPTION
Terraform v0.11.3 - later version of terraform cause the following. this commit has the fix
```
cloudformation stack does not have attribute 'outputs.ARN'
```