### PR TITLE
Remove incorrect provider notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ creates using the `additional_tags` input when calling the module.
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | additional_tags | The tags to apply to resources created by this module | map | `<map>` | no |
-| aws_region | AWS region | string | `eu-west-1` | no |
 | display_name | Name shown in confirmation emails | string | `tf_sns_email` | no |
 | email_address | Email address to send notifications to | string | - | yes |
 | owner | Sets the owner tag on the CloudFormation stack | string | `tf_sns_email` | no |

--- a/providers.tf
+++ b/providers.tf
@@ -1,8 +1,0 @@
-provider "aws" {
-  region  = "${var.aws_region}"
-  version = "~> 1.30.0"
-}
-
-provider "template" {
-  version = "~> 1.0.0"
-}

--- a/variables.tf
+++ b/variables.tf
@@ -4,12 +4,6 @@ variable "additional_tags" {
   type        = "map"
 }
 
-variable "aws_region" {
-  type        = "string"
-  description = "AWS region"
-  default     = "eu-west-1"
-}
-
 variable "display_name" {
   type        = "string"
   description = "Name shown in confirmation emails"


### PR DESCRIPTION
Provider configuration in the module leads to some issues when one tries to delete the module.

See https://github.com/hashicorp/terraform/issues/17928 for details.

A proper way to handle different region also could be found in that issue mentioned above.